### PR TITLE
Release 7.0.1

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['5.5.1']
+        version: ['7.0.1']
         service: ['zookeeper', 'kafka']
     steps:
       - name: Checkout

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,12 @@ RUN python3 get-pip.py "pip==9.0.3" \
   && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20
 
 COPY newtar.tar.gz /newtar.tar.gz
+
+# --exclude keeps newtar's python3 from stomping our base image's python3.
+# Possibly this is an indication we should exclude more layers, but ... it
+# works?
+RUN tar xzf newtar.tar.gz --exclude /usr/bin/python3
+
 COPY cmd /etc/confluent/docker/run
 
 # Don't overwrite PATH, because openjdk:18 uses that

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-set -euo pipefail
-set -x
+set -euxo pipefail
+
 service=${1-}
 version=$2
 if ! [[ "$service" == "zookeeper" || "$service" == "kafka" ]]; then
     echo "Not recognized."
     exit 1
 fi
-rm -r $service || true
+sudo rm -rf $service || true
 mkdir -p $service
 cd $service
 confluent_image="confluentinc/cp-$service:$version"
@@ -68,7 +68,7 @@ if [[ -z ${github_build-} ]]; then
   if [[ "$(arch)" == "x86_64" ]]; then
     platform=${platform:-linux/amd64}
   else
-    platform=${platform:-linux/amd64}
+    platform=${platform:-linux/arm64}
   fi
 
   # buildx --load currently only works with one platform. If we were using --push,

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ layers=$(cat manifest.json \
     | tail -n +3)
 mkdir newtar; cd newtar
 for l in $layers; do
+    # I don't know why the previous kafka:7.0.x could do without this chmod;  I
+    # expect it's overwriting files in layers that it wasn't before
+    chmod a+w -R ../newtar
     tar -xf ../$l
 done
 cd -
@@ -41,7 +44,7 @@ FROM openjdk:18-jdk-bullseye
 # This is in the 2nd layer, but is not cross-platform, so we install it here
 COPY get-pip.py .
 
-RUN apt update && apt install -y python3-distutils python3-pip
+RUN apt update && apt install -y python3-distutils
 
 # I don't know why confluent-docker-utils fails to install with pip>9.0.3, but
 # it does: https://stackoverflow.com/a/51153611

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ cd -
 
 cp ../cmd .
 cp ../get-pip.py .
-tar -cvzf newtar.tar.gz newtar --transform='s/^newtar//g'
+sudo tar -czf newtar.tar.gz newtar --transform='s/^newtar//g'
 rm -rf newtar
 
 # Delete unneeded files so the build context is smaller.

--- a/build.sh
+++ b/build.sh
@@ -36,14 +36,16 @@ rm *.json
 rm -r repositories
 
 cat > Dockerfile <<- EOF
-FROM openjdk:18-jdk-buster
+FROM openjdk:18-jdk-bullseye
 
 # This is in the 2nd layer, but is not cross-platform, so we install it here
 COPY get-pip.py .
 
+RUN apt update && apt install -y python3-distutils python3-pip
+
 # I don't know why confluent-docker-utils fails to install with pip>9.0.3, but
 # it does: https://stackoverflow.com/a/51153611
-RUN python get-pip.py "pip==9.0.3" \
+RUN python3 get-pip.py "pip==9.0.3" \
   && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20
 
 COPY newtar.tar.gz /newtar.tar.gz

--- a/cmd
+++ b/cmd
@@ -1,9 +1,14 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
-tar -xzvf /newtar.tar.gz
+# --exclude keeps newtar's python3 from stomping our base image's python3.
+# Possibly this is an indication we should exclude more layers, but ... it
+# works?
+tar -xzf /newtar.tar.gz --exclude /usr/bin/python3
 
 chmod +x /etc/confluent/docker/run
+
+set +x
 
 # The untar above replaced this file with the real one
 exec /etc/confluent/docker/run

--- a/cmd
+++ b/cmd
@@ -1,14 +1,13 @@
 #!/bin/bash
 set -euxo pipefail
 
-# --exclude keeps newtar's python3 from stomping our base image's python3.
-# Possibly this is an indication we should exclude more layers, but ... it
-# works?
-tar -xzf /newtar.tar.gz --exclude /usr/bin/python3
-
+# We should use this as the cmd, but, it calls /etc/confluent/docker/ensure,
+# which fails with
+# Error: Could not find or load main class .usr.share.java.cp-base-new.audience-annotations-0.5.0.jar
+# Caused by: java.lang.ClassNotFoundException: /usr/share/java/cp-base-new/audience-annotations-0/5/0/jar
+# And I'm not sure why; that file exists. Setting
+# CLASSPATH=/usr/share/java/cp-base-new doesn't seem to help.
 chmod +x /etc/confluent/docker/run
 
-set +x
-
-# The untar above replaced this file with the real one
-exec /etc/confluent/docker/run
+/etc/confluent/docker/configure
+exec /etc/confluent/docker/launch


### PR DESCRIPTION
This PR updates us to 7.0.1.

In addition, we:
- upgrade from buster -> bullseye (since confluent's scripts now want python 3 )
- deal with some permission garbage in the tar -x (not ideal for security, but - these images are intended for local use only)
